### PR TITLE
Remove description from project_naming output

### DIFF
--- a/root/locals.tofu
+++ b/root/locals.tofu
@@ -29,7 +29,6 @@ locals {
 
   # Project naming components for downstream consumption
   project_naming = local.team_data != null ? {
-    description = lower(local.team_data.display_name)
     prefix      = local.team_prefix
     team_key    = local.team_key
     team_prefix = local.team_prefix

--- a/root/outputs.tofu
+++ b/root/outputs.tofu
@@ -22,7 +22,7 @@ output "labels" {
 }
 
 output "project_naming" {
-  description = "The project naming configuration from logos state"
+  description = "The project naming configuration from logos state. Contains prefix, team_key, and team_prefix."
   value       = local.project_naming
 }
 


### PR DESCRIPTION
## Summary

Removes the `description` field from the `project_naming` output. This field was `lower(local.team_data.display_name)` and was only consumed by `pt-corpus` to pass as `description` to `module "google_project"`.

Part of the re-architecture to remove `var.description` from `pt-arche-google-project` ([PR #176](https://github.com/osinfra-io/pt-arche-google-project/pull/176)) so that project IDs use the format `{prefix}-{random}-{env}` instead of `{prefix}-{description}-{random}-{env}`.

## Changes

- `root/locals.tofu`: Remove `description` from `project_naming` map
- `root/outputs.tofu`: Update `project_naming` output description to reflect removed field

## Release

MINOR version bump

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project naming output description to clarify included configuration fields.

* **Chores**
  * Simplified project naming configuration structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->